### PR TITLE
Add docker support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.5
+
+COPY requirements.txt /projects/
+
+RUN pip install -r /projects/requirements.txt

--- a/README.md
+++ b/README.md
@@ -24,6 +24,60 @@ $ python manage.py migrate
 $ python manage.py runserver
 ```
 
+#### Using Docker (optional)
+
+A Docker setup potentially makes development and deployment easier.
+
+To use it, install [Docker][] and [Docker Compose][]. (If you're on OS X or
+Windows, you'll also have to explicitly start the Docker Quickstart Terminal,
+at least until [Docker goes native][].)
+
+Then run:
+
+```
+docker-compose run app python manage.py migrate
+```
+
+There's a good chance this will fail with Django complaining that it can't
+connect to the database. If this happens, just re-run the command again.
+This is happening because the postgres container takes a little while to set
+up the initial database.
+
+Once the above command is successful, run:
+
+```
+docker-compose up
+```
+
+This will start up all required servers in containers and output their
+log information to stdout. If you're on Linux, you should be able
+to visit http://localhost:8000/ directly to access the site. If you're on
+OS X or Windows, you'll likely have to visit port 8000 on the IP
+address given to you by `docker-machine ip default`. (Note that this 
+hassle will go away once [Docker goes native][] for OS X/Windows.)
+
+##### Accessing the app container
+
+You'll likely want to run `manage.py` to do other things at some point.
+To do this, it's probably easiest to run:
+
+```
+docker-compose run app bash
+```
+
+This will run an interactive bash session inside the main app container.
+In this container, the `/projects` directory is mapped to the root of
+the repository on your host; you can run `manage.py` from there.
+
+Note that if you don't have Django installed on your host system, you
+can just run `python manage.py` directly from outside the container--the
+`manage.py` script has been modified to run itself in a Docker container
+if it detects that Django isn't installed.
+
+[Docker]: https://www.docker.com/
+[Docker Compose]: https://docs.docker.com/compose/
+[Docker goes native]: https://blog.docker.com/2016/03/docker-for-mac-windows-beta/
+
 #### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md).   As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+app:
+  build: .
+  volumes:
+    - .:/projects
+  links:
+    - db
+  working_dir: /projects
+  entrypoint: python /projects/entrypoint.py
+  environment:
+    - DATABASE_URL=postgres://db/18fprojects
+  command: python manage.py runserver 0.0.0.0:8000
+  ports:
+    - "8000:8000"
+db:
+  image: postgres:9.4
+  environment:
+    - POSTGRES_DB=18fprojects
+    - POSTGRES_USER=projects_user

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python
+
+"""
+    This is a Docker entrypoint that configures the container to run
+    as the same uid of the user on the host container, rather than
+    the Docker default of root. Aside from following security best
+    practices, this makes it so that any files created by the Docker
+    container are also owned by the same user on the host system.
+"""
+
+import sys
+import os
+import pwd
+import subprocess
+
+HOST_UID = os.stat('/projects').st_uid
+HOST_USER = os.environ.get('HOST_USER', 'projects_user')
+
+def does_username_exist(username):
+    try:
+        pwd.getpwnam(username)
+        return True
+    except KeyError:
+        return False
+
+def does_uid_exist(uid):
+    try:
+        pwd.getpwuid(uid)
+        return True
+    except KeyError:
+        return False
+
+if __name__ == '__main__':
+    if HOST_UID != os.geteuid():
+        if not does_uid_exist(HOST_UID):
+            username = HOST_USER
+            while does_username_exist(username):
+                username += '0'
+            home_dir = '/home/%s' % username
+            #print "Creating username %s with UID %d" % (username, HOST_UID)
+            subprocess.check_call([
+                'useradd',
+                '-d', home_dir,
+                '-m', username,
+                '-u', str(HOST_UID)
+            ])
+        os.environ['HOME'] = '/home/%s' % pwd.getpwuid(HOST_UID).pw_name
+        os.setuid(HOST_UID)
+    os.execvp(sys.argv[1], sys.argv[1:])

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -16,12 +16,14 @@ import subprocess
 HOST_UID = os.stat('/projects').st_uid
 HOST_USER = os.environ.get('HOST_USER', 'projects_user')
 
+
 def does_username_exist(username):
     try:
         pwd.getpwnam(username)
         return True
     except KeyError:
         return False
+
 
 def does_uid_exist(uid):
     try:
@@ -37,7 +39,6 @@ if __name__ == '__main__':
             while does_username_exist(username):
                 username += '0'
             home_dir = '/home/%s' % username
-            #print "Creating username %s with UID %d" % (username, HOST_UID)
             subprocess.check_call([
                 'useradd',
                 '-d', home_dir,

--- a/manage.py
+++ b/manage.py
@@ -2,9 +2,55 @@
 import os
 import sys
 
+def setup_docker_sigterm_handler():
+    '''
+    'manage.py runserver' is not set up to deal with a SIGTERM signal,
+    and instead expects a Ctrl-C to come to its child process. So we'll
+    add a SIGTERM handler here that finds all our children and gracefully
+    shuts them down, which provides a quick graceful exit from Docker.
+    '''
+
+    if not (len(sys.argv) > 1 and sys.argv[1] == 'runserver'):
+        return
+
+    import signal
+    import subprocess
+
+    def get_children():
+        output = subprocess.check_output(
+            "ps --ppid=%d -o pid | awk 'NR>1' | xargs echo" % os.getpid(),
+            shell=True
+        )
+        return map(int, output.split())
+
+    def handler(signum, frame):
+        for child_pid in get_children():
+            try:
+                os.kill(child_pid, signal.SIGTERM)
+                os.waitpid(child_pid, 0)
+            except OSError:
+                pass
+        sys.exit(0)
+
+    print("Setting up Docker SIGTERM handler for quick, graceful exit.")
+    signal.signal(signal.SIGTERM, handler)
+
 if __name__ == "__main__":
+    if os.getcwd() == '/projects': setup_docker_sigterm_handler()
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
-    from django.core.management import execute_from_command_line
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as e:
+        # Assume the user wants to run us in docker.
+        try:
+            os.execvp('docker-compose', [
+                'docker-compose', 'run', 'app', 'python'
+            ] + sys.argv)
+        except OSError:
+            # Apparently docker-compose isn't installed, so just raise
+            # the original ImportError.
+            raise e
 
     execute_from_command_line(sys.argv)

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,7 @@
 import os
 import sys
 
+
 def setup_docker_sigterm_handler():
     '''
     'manage.py runserver' is not set up to deal with a SIGTERM signal,
@@ -36,7 +37,8 @@ def setup_docker_sigterm_handler():
     signal.signal(signal.SIGTERM, handler)
 
 if __name__ == "__main__":
-    if os.getcwd() == '/projects': setup_docker_sigterm_handler()
+    if os.getcwd() == '/projects':
+        setup_docker_sigterm_handler()
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 


### PR DESCRIPTION
This adds support for developing the server using Docker. It includes:
- Instructions on how to get started in the README.
- A [Dockerfile](https://docs.docker.com/engine/reference/builder/) and [compose file](https://docs.docker.com/compose/compose-file/) that set up the main Django app container and a postgres db container and link them together.
- A [Docker entrypoint](https://docs.docker.com/engine/reference/builder/#entrypoint) that sets the user of the app container to the same uid as the host system, so that any files created by the app container don't have weird permissions on the host system. (Eventually docker will likely support such mappings itself, but for now we have to write a custom solution, which is a bit annoying.)
- A convenient shortcut allowing `manage.py` to be used directly from the host system, under certain circumstances (see the README for more information on this).
- A signal handler in `manage.py` allowing `manage.py runserver` to gracefully exit.

Note that this doesn't actually set up docker for _production_ use. We can eventually do that if we want, though, for [dev/prod parity win](http://12factor.net/dev-prod-parity), but I'm not sure how compatible it is with the workings of cloud.gov or anything like that.
