### PR TITLE
[WIP] Add /api/ endpoint

### DIFF
--- a/api/apps.py
+++ b/api/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ApiConfig(AppConfig):
+    name = 'api'

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from projects.models import Project
+
+
+class ApiTests(TestCase):
+    def test_api_root_is_ok(self):
+        response = self.client.get('/api/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_projects_is_ok(self):
+        response = self.client.get('/api/projects/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_projects_pk_is_ok(self):
+        project = Project(name='Boop')
+        project.save()
+
+        response = self.client.get('/api/projects/%d/' % project.id)
+        self.assertEqual(response.status_code, 200)
+
+        json = response.json()
+
+        self.assertEqual(json['name'], 'Boop')

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import include, url
+
+from rest_framework import routers
+
+from . import views
+
+router = routers.DefaultRouter()
+
+router.register(r'projects', views.ProjectsViewSet, base_name='projects')
+
+urlpatterns = [
+    url(r'^', include(router.urls))
+]

--- a/api/views.py
+++ b/api/views.py
@@ -1,0 +1,36 @@
+from rest_framework import viewsets, serializers
+from rest_framework.mixins import RetrieveModelMixin, ListModelMixin
+
+from projects import models
+
+
+class ProjectSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = models.Project
+        fields = (
+            'name',
+            'slug',
+            'tagline',
+            'project_lead',
+            'description',
+            'impact',
+            'live_site_url',
+            'github_url',
+            'status',
+            'billable',
+            'cloud_dot_gov',
+            'tock_id',
+            'mb_number',
+        )
+
+
+class ReadOnlyViewSet(RetrieveModelMixin, ListModelMixin,
+                      viewsets.GenericViewSet):
+    pass
+
+
+class ProjectsViewSet(ReadOnlyViewSet):
+    serializer_class = ProjectSerializer
+
+    def get_queryset(self):
+        return models.Project.objects.all()

--- a/app/settings.py
+++ b/app/settings.py
@@ -14,10 +14,12 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'test_without_migrations',
 
     'projects',
     'web',
+    'api',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -68,3 +70,10 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 
 STATICFILES_DIRS = ()
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+
+REST_FRAMEWORK = {
+    'UNICODE_JSON': False,
+    'DEFAULT_PAGINATION_CLASS': ('rest_framework.pagination.'
+                                 'PageNumberPagination'),
+    'PAGE_SIZE': 25,
+}

--- a/app/urls.py
+++ b/app/urls.py
@@ -4,5 +4,6 @@ from django.contrib import admin
 
 urlpatterns = [
     url(r'^', include('web.urls')),
+    url(r'^api/', include('api.urls')),
     url(r'^admin/', admin.site.urls),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psycopg2==2.6.1
 pyflakes==1.0.0
 whitenoise==3.0
 django-test-without-migrations==0.4
+djangorestframework==3.3.3


### PR DESCRIPTION
This attempts to add a [Django REST framework](http://www.django-rest-framework.org/)-powered API at `/api/`.

To do:
- [ ] Consider exposing `Client` endpoint.
- [ ] Figure out how we want to expose the related `Client` for a `Project` in the `/projects/` endpoint. For instance, do we want to embed the information inside each project, or do we want it to be a primary key that needs to be looked up at a `/clients/{pk}` endpoint?
- [ ] Figure out how we want to represent our model fields that have [`choices`](https://docs.djangoproject.com/en/1.9/ref/models/fields/#choices) options. Currently, for example, `Project.status` is an integer that corresponds to tentative/active/paused/complete. But we might instead want this to be an actual string describing the choice.
- [ ] Figure out what fields we want to expose on `Project`. For example, do we want to expose `mb_number`? Alternatively, do we want to expose only a strict subset of fields by default, but show additional fields if they're specified as querystring arguments?
- [ ] Add CORS support for the API.
