### PR TITLE
Explicitly specify user in docker DATABASE_URL.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ app:
   working_dir: /projects
   entrypoint: python /projects/entrypoint.py
   environment:
-    - DATABASE_URL=postgres://db/18fprojects
+    - DATABASE_URL=postgres://projects_user@db/18fprojects
   command: python manage.py runserver 0.0.0.0:8000
   ports:
     - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ app:
   working_dir: /projects
   entrypoint: python /projects/entrypoint.py
   environment:
+    - PYTHONUNBUFFERED=yup
     - DATABASE_URL=postgres://projects_user@db/18fprojects
   command: python manage.py runserver 0.0.0.0:8000
   ports:


### PR DESCRIPTION
There are some edge cases where the username of the process running `manage.py` isn't `projects_user`, so it's best to be explicit here.

This also defines [`PYTHONUNBUFFERED`](https://docs.python.org/2/using/cmdline.html#envvar-PYTHONUNBUFFERED) so that the stdout from `manage.py runserver` always shows up.
