### PR TITLE
Pre-populate slug field

### DIFF
--- a/projects/admin.py
+++ b/projects/admin.py
@@ -20,3 +20,4 @@ class ProjectAdmin(admin.ModelAdmin):
     list_display = ('name', 'status', 'client',)
     list_filter = ('status', 'is_billable', 'cloud_dot_gov', 'is_visible')
     search_fields = ('name',)
+    prepopulated_fields = {"slug": ("name",)}


### PR DESCRIPTION
This fixes #36.

In the screenshot below, the user has only entered the Project's name; Django admin has pre-populated the slug field for them:

![prepopulate_slug](https://cloud.githubusercontent.com/assets/124687/15963174/e69b354a-2edd-11e6-852b-3cc01ba038a7.png)
