### PR TITLE
start adding github org oauth

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -31,6 +31,8 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
 ]
 
 ROOT_URLCONF = 'app.urls'
@@ -110,3 +112,4 @@ AUTHENTICATION_BACKENDS = (
 SOCIAL_AUTH_GITHUB_ORG_NAME = '18F'
 SOCIAL_AUTH_GITHUB_ORG_KEY = os.environ.get('GITHUB_ORG_KEY')
 SOCIAL_AUTH_GITHUB_ORG_SECRET = os.environ.get('GITHUB_ORG_SECRET')
+SOCIAL_AUTH_LOGIN_ERROR_URL = '/'

--- a/app/settings.py
+++ b/app/settings.py
@@ -14,7 +14,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
     'test_without_migrations',
+    'social.apps.django_app.default',
 
     'projects',
     'web',
@@ -99,3 +101,12 @@ LOGGING = {
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_BUCKET = os.environ.get('AWS_BUCKET')
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'social.backends.github.GithubOrganizationOAuth2',
+)
+
+SOCIAL_AUTH_GITHUB_ORG_NAME = '18F'
+SOCIAL_AUTH_GITHUB_ORG_KEY = os.environ.get('GITHUB_ORG_KEY')
+SOCIAL_AUTH_GITHUB_ORG_SECRET = os.environ.get('GITHUB_ORG_SECRET')

--- a/app/urls.py
+++ b/app/urls.py
@@ -4,5 +4,6 @@ from django.contrib import admin
 
 urlpatterns = [
     url(r'^', include('web.urls', namespace='web')),
+    url('^auth/', include('social.apps.django_app.urls', namespace='social')),
     url(r'^admin/', admin.site.urls),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ psycopg2==2.6.1
 ptyprocess==0.5.1
 pyflakes==1.0.0
 python-dateutil==2.5.3
+python-social-auth==0.2.19
 simplegeneric==0.8.1
 six==1.10.0
 traitlets==4.2.1

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -11,6 +11,13 @@
   <div class="h6 p1 bg-black white center caps">Work in Progress</div>
   <div class="container px2 py3">
     <div class="mb4">
+      <div class="right">
+        {% if request.user.is_authenticated %}
+        {{ request.user }} <a href="{% url 'web:logout' %}">Logout</a>
+        {% else %}
+        <a href="{% url 'social:begin' 'github-org' %}?next={{ request.path }}">Login with Github</a>
+        {% endif %}
+      </div>
       <a href="/" class="h1 p0 btn">
         <img src="/static/img/logo.png" class="align-middle" width="75">
         <span class="bold gray">/projects</span>

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,10 +1,12 @@
 from django.conf.urls import url
 
 from web.views.home import HomeView
+from web.views.logout import LogoutView
 from web.views.project import ProjectView
 
 
 urlpatterns = [
     url(r'^$', HomeView.as_view(), name='home'),
+    url(r'^logout$', LogoutView.as_view(), name='logout'),
     url(r'^p/(?P<pk>[\w/\-]+)?$', ProjectView.as_view(), name='project'),
 ]

--- a/web/views/logout.py
+++ b/web/views/logout.py
@@ -1,0 +1,9 @@
+from django.contrib.auth import logout
+from django.shortcuts import redirect
+from django.views.generic import View
+
+
+class LogoutView(View):
+    def get(self, request, *args, **kwargs):
+        logout(request)
+        return redirect('web:home')


### PR DESCRIPTION
this adds github login for 18F organization members

right now, this only works locally (localhost:8000) -- will need to add another github app for prod environment (and break out our dev/prod settings)

if you're not in the 18F org and try to authenticate, you get redirected to homepage (TODO: this should also display a flash message to the user alerting them why it didn't work)
